### PR TITLE
add DOS game type, A-Train, Railroad Tycoon, SimHealth, SimFarm, Simtower

### DIFF
--- a/src/data/games/gamesA.ts
+++ b/src/data/games/gamesA.ts
@@ -191,4 +191,45 @@ export const gamesA: Game[] = [
     gameplayType: [GameplayType.BuildingBlocks],
     pricing: [Pricing.NotSet],
   },
+  {
+    title: "A-Train (1985)",
+    description: "First in a long series of business simulation video games about trains. Released in December 1985 for the FM-7, NEC PC-8801, NEC PC-9801, X1 Turbo, MZ-2500, Famicom, and MSX2. The third game in the series (1990) was known as A-Train internationally, and A-Train III in Japan.",
+    year: 1985,
+    themes: [Theme.Railroads, Theme.Transportation],
+    platforms: [],
+    stores: [],
+    links: [
+      {
+        url: "https://en.wikipedia.org/wiki/A-Train",
+        name: "Wikipedia"
+      }
+    ],
+    gameplayType: [GameplayType.Isometric],
+    pricing: [Pricing.NotSet]
+  },
+  {
+    title: "A-Train (1990)",
+    description: "The internationally distributed A-Train, known as A-Train III within Japan. Released 1992 for DOS. Also released for 	PC-9800, FM-Towns, X68000, Amiga, DOS, Macintosh, PlayStation, Super Famicom, Windows 95, Virtual Console. Isometric train company builder with business simulation including stock market and investments. Developer was Artdink, publisher is Maxis in North America and Ocean Software in EU.",
+    year: 1990,
+    themes: [Theme.Railroads, Theme.Transportation],
+    platforms: [Platform.PC, Platform.Mac],
+    stores: [],
+    links: [
+      {
+        url: "https://www.myabandonware.com/game/a-train-1bn",
+        name: Store.AbandonWare
+      },
+      {
+        url: "https://en.wikipedia.org/wiki/A-Train_III",
+        name: "Wikipedia"
+      },
+      {
+        url: "https://www.macintoshrepository.org/4768-a-train",
+        name: Store.AbandonWare
+      }
+
+    ],
+    gameplayType: [GameplayType.Isometric],
+    pricing: [Pricing.NotSet]
+  }
 ];

--- a/src/data/games/gamesA.ts
+++ b/src/data/games/gamesA.ts
@@ -193,7 +193,7 @@ export const gamesA: Game[] = [
   },
   {
     title: "A-Train (1985)",
-    description: "First in a long series of business simulation video games about trains. Released in December 1985 for the FM-7, NEC PC-8801, NEC PC-9801, X1 Turbo, MZ-2500, Famicom, and MSX2. The third game in the series (1990) was known as A-Train internationally, and A-Train III in Japan.",
+    description: "First in a long series of business simulation video games about trains. Released in December 1985 for the FM-7, NEC PC-8801, NEC PC-9801, X1 Turbo, MZ-2500, Famicom, and MSX2. The third game in the series (1990) was known as A-Train internationally, and A-Train III in Japan. (The 1985 version does not seem to be available online.)",
     year: 1985,
     themes: [Theme.Railroads, Theme.Transportation],
     platforms: [],
@@ -205,7 +205,8 @@ export const gamesA: Game[] = [
       }
     ],
     gameplayType: [GameplayType.Isometric],
-    pricing: [Pricing.NotSet]
+    pricing: [Pricing.Free],
+    sequelFamily: "A-Train",
   },
   {
     title: "A-Train (1990)",
@@ -226,10 +227,15 @@ export const gamesA: Game[] = [
       {
         url: "https://www.macintoshrepository.org/4768-a-train",
         name: Store.AbandonWare
+      },
+      {
+        url: "https://openretro.org/amiga/a-train",
+        name: Store.AbandonWare
       }
 
     ],
     gameplayType: [GameplayType.Isometric],
-    pricing: [Pricing.NotSet]
+    pricing: [Pricing.Free],
+    sequelFamily: "A-Train",
   }
 ];

--- a/src/data/games/gamesR.ts
+++ b/src/data/games/gamesR.ts
@@ -2,6 +2,22 @@ import { Game, Theme, Platform, Store, GameplayType, Pricing } from "./types";
 
 export const gamesR: Game[] = [
   {
+    title: "Railroad Tycoon",
+    description: "A series of business simulation games released in 1990, Railroad Tycoon Deluxe (1993), Railroad Tycoon II (1998), Railroad Tycoon 3 (2003) and Sid Meier's Railroads! (2006). Original version written by Sid Meier and published by Microprose. ",
+    year: 1990,
+    themes: [Theme.Industry, Theme.Railroads],
+    platforms: [Platform.DOS, Platform.Mac, Platform.PC, Platform.Linux],
+    stores: [Store.AbandonWare],
+    links: [ 
+      {
+        url: "https://en.wikipedia.org/wiki/Railroad_Tycoon",
+        name: "Wikipedia"
+      },
+    ],
+    gameplayType: [GameplayType.TopDown2D],
+    pricing: [Pricing.NotSet]
+  },
+  {
     title: "Rise of Industry",
     description:
       "Put your entrepreneurial skills to the test in the first title in the ROI series as you create & optimise intricate production lines. As an early 20th-Century industrialist, grow your empire & adapt to an ever-changing business landscape with unexpected events that could lead to boom…or bust.",

--- a/src/data/games/gamesS.ts
+++ b/src/data/games/gamesS.ts
@@ -160,6 +160,66 @@ export const gamesS: Game[] = [
     pricing: [Pricing.MoreThan10LessThan30],
   },
   {
+    title: "SimTower",
+    description: "A construction and management simulation released in 1994 for MS Windows and Macintosh System 7 building a vertical tower with elevators, managing the business of the tower, placing facilities and elevators in it. Developed by Yoot Saito and published by Maxis in North America and Europe. A sequel, Yoot Tower, was released in 1998. It was also released on 3DO and Sega Saturn",
+    year: 1994,
+    themes: [Theme.GeneralBusiness, Theme.ShoppingCentre, Theme.PropertyRentals, Theme.Office],
+    stores: [Store.AbandonWare],
+    links: [
+      {
+        url: "https://en.wikipedia.org/wiki/SimTower",
+        name: "Wikipedia",
+      },
+      {
+        url: "https://www.myabandonware.com/game/simtower-the-vertical-empire-3f2",
+        name: Store.AbandonWare
+      }
+    ],
+    gameplayType: [GameplayType.BuildingBlocks],
+    pricing: [Pricing.Free],
+    platforms: [Platform.PC, Platform.Mac]
+  },
+  {
+    title: "SimFarm",
+    description: "A video game where players build and maange a virtual farm, released as a spinoff of SimCity in 1993.",
+    year: 1995,
+    themes: [Theme.Farming],
+    platforms: [Platform.PC, Platform.Mac],
+    stores: [Store.AbandonWare],
+    links: [
+      {
+        url: "https://www.myabandonware.com/game/sim-farm-204",
+        name: Store.AbandonWare
+      },
+      {
+        url: "https://en.wikipedia.org/wiki/SimFarm",
+        name: "Wikipedia"
+      }
+    ],
+    gameplayType: [GameplayType.TopDown2D],
+    pricing: [Pricing.Free]
+  },
+  {
+    title: "SimHealth",
+    description: "A management simulation published in 1994 by Maxis to simulate the US health care system. Developed by Thinking Tools. Interface inspired by Simcity 2000",
+    year: 1994,
+    themes: [Theme.GeneralBusiness],
+    platforms: [Platform.DOS],
+    stores: [Store.AbandonWare],
+    links: [
+      {
+        url: "https://en.wikipedia.org/wiki/SimHealth",
+        name: "Wikipedia"
+      },
+      {
+        url: "https://www.myabandonware.com/game/simhealth-2am",
+        name: Store.AbandonWare
+      }
+    ],
+    gameplayType: [GameplayType.Isometric],
+    pricing: [Pricing.Free]
+  },
+  {
     title: "Smart Factory Tycoon",
     description:
       "Smart Factory Tycoon inspired by Little Big Workshop is a tycoon management game about running your dream factory with robots. Design your dream factory, plan all steps of production, research new technologies and become a tycoon!",

--- a/src/data/games/gamesT.ts
+++ b/src/data/games/gamesT.ts
@@ -219,4 +219,21 @@ export const gamesT: Game[] = [
     gameplayType: [GameplayType.TopDown2D],
     pricing: [Pricing.MoreThan10LessThan30],
   },
+	{
+    title: "The Executive - Movie Industry Tycoon",
+    description: "Shape the history of the Hollywood movie industry in this sandbox business simulation game. Create the movies you've always wanted to see, hire the best team, research cutting-edge technologies, and dominate the Box Office. Can you rise from a small studio to a Hollywood giant?",
+    releaseDate: "TBA",
+    year: 2025,
+    themes: [Theme.Movies],
+    platforms: [Platform.PC],
+    stores: [Store.Steam],
+    links: [
+      {
+        url: "https://store.steampowered.com/app/2315430/?utm_source=TycoonList",
+        name: Store.Steam,
+      },
+    ],
+    gameplayType: [GameplayType.Isometric],
+    pricing: [Pricing.NotSet],
+	},
 ];

--- a/src/data/games/types.ts
+++ b/src/data/games/types.ts
@@ -69,11 +69,8 @@ export enum Platform {
   Linux = "Linux",
   Xbox = "Xbox",
   PlayStation = "PlayStation",
-<<<<<<< HEAD
   DOS = "DOS",
-=======
   Browser = "Browser",
->>>>>>> 1278bbdb1972f000d3e75cd047ef3fe7eb439c10
 }
 
 export enum Store {

--- a/src/data/games/types.ts
+++ b/src/data/games/types.ts
@@ -69,6 +69,7 @@ export enum Platform {
   Linux = "Linux",
   Xbox = "Xbox",
   PlayStation = "PlayStation",
+  DOS = "DOS",
 }
 
 export enum Store {


### PR DESCRIPTION
Figured it made sense to add a type specifically for DOS if not the really old PC platforms that predated it. as well as the first and more famous third edition of A-train.